### PR TITLE
Add 'scapy' and 'colorama' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 wifi
+scapy
+colorama


### PR DESCRIPTION
Scapy and colorama are both non-default modules and should be added to requirements.txt